### PR TITLE
Run analysis on Hyper

### DIFF
--- a/.build_scripts/insert-env.js
+++ b/.build_scripts/insert-env.js
@@ -13,11 +13,17 @@ let obj = YAML.load(input)
 // Switch based on environment
 if (process.env.TRAVIS_BRANCH === process.env.STABLE_BRANCH) {
   var latest_tag = 'latest-stable'
-  obj['rra-api']['environment'] = ['DS_ENV=production']
+  var dsEnv = 'production'
 } else {
   latest_tag = 'latest-dev'
-  obj['rra-api']['environment'] = ['DS_ENV=staging']
+  dsEnv = 'staging'
 }
+
+obj['rra-api']['environment'] = [
+  `HYPER_ACCESS=${process.env['HYPER_ACCESS']}`,
+  `HYPER_SECRET=${process.env['HYPER_SECRET']}`,
+  `DS_ENV=${dsEnv}`
+]
 
 // Set container version based on hash. Falls back to latest tag
 let hash = process.env.TRAVIS_COMMIT || latest_tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:6-alpine
+FROM node:6
 ADD . /dist
 WORKDIR /dist
+RUN bash install.sh
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ The following options must be set: (The used file will depend on the context)
   - `storageTest.secretKey` - Secret key for storage. [STORAGE_TEST_SECRET_KEY]
   - `storageTest.bucket` - Secret key for storage. [STORAGE_TEST_BUCKET]
   - `storageTest.region` - Secret key for storage. [STORAGE_TEST_REGION]
+  - `analysisProcess.service` - The service to run the analysis on. Either `docker` (for local development and off-line) or `hyper`. [ANL_SERVICE]
+  - `analysisProcess.hyperAccess` - Access key for Hyper. [HYPER_ACCESS]
+  - `analysisProcess.hyperSecret` - Secret key for Hyper. [HYPER_SECRET]
+  - `analysisProcess.container` - The name of the rra-analysis container (Default wbtransport/rra-analysis:latest-stable) [ANL_CONTAINER]
+  - `analysisProcess.db` - The database connection string. When using Docker for the analysis process, the host will the Docker inet address ($ ifconfig). When using Hyper, this will be the IP of your hosted database [ANL_DB]
+  - `analysisProcess.storageHost` - The host of the storage service. See notes above. [ANL_STORAGE_HOST]
+  - `analysisProcess.storagePort` - The port to use. [ANL_STORAGE_PORT]
+ 
 
 Example:
 ``` 
@@ -116,6 +124,15 @@ module.exports = {
     secretKey: 'miniostorageengine',
     bucket: 'rra-test',
     region: 'us-east-1'
+  },
+  analysisProcess: {
+    service: 'docker',
+    hyperAccess: null,
+    hyperSecret: null,
+    container: 'wbtransport/rra-analysis:latest-stable',
+    db: 'postgresql://rra:rra@172.17.0.1:5432/rra',
+    storageHost: '172.17.0.1',
+    storagePort: 9000
   }
 };
 ```
@@ -150,6 +167,7 @@ Follow these steps to set up a deployment to an ECS Cluster:
 3. SSH into the machine with your Key Pair to set up the basic database structure  
   - run `docker ps` and to find the Container ID of `rra-api`
   - run `docker exec [container_id] npm run setup -- --db --bucket`
+4. [to come] deployment of the Analysis process
 
 This should set up the basic cluster that Travis can push the backend to.
 

--- a/app/config.js
+++ b/app/config.js
@@ -41,10 +41,13 @@ config.storageTest.secretKey = process.env.STORAGE_TEST_SECRET_KEY || config.sto
 config.storageTest.bucket = process.env.STORAGE_TEST_BUCKET || config.storageTest.bucket;
 config.storageTest.region = process.env.STORAGE_TEST_REGION || config.storageTest.region;
 
+config.analysisProcess.service = process.env.ANL_SERVICE || config.analysisProcess.service;
 config.analysisProcess.container = process.env.ANL_CONTAINER || config.analysisProcess.container;
 config.analysisProcess.db = process.env.ANL_DB || config.analysisProcess.db;
 config.analysisProcess.storageHost = process.env.ANL_STORAGE_HOST || config.analysisProcess.storageHost;
 config.analysisProcess.storagePort = process.env.ANL_STORAGE_PORT || config.analysisProcess.storagePort;
+config.analysisProcess.hyperAccess = process.env.HYPER_ACCESS || config.analysisProcess.hyperAccess;
+config.analysisProcess.hyperSecret = process.env.HYPER_SECRET || config.analysisProcess.hyperSecret;
 
 config.baseDir = __dirname;
 

--- a/app/config/production.js
+++ b/app/config/production.js
@@ -28,6 +28,7 @@ module.exports = {
   analysisProcess: {
     service: null,
     hyperAccess: null,
+    hyperSecret: null,
     container: null,
     db: null,
     storageHost: null,

--- a/app/config/production.js
+++ b/app/config/production.js
@@ -26,6 +26,8 @@ module.exports = {
     region: null
   },
   analysisProcess: {
+    service: null,
+    hyperAccess: null,
     container: null,
     db: null,
     storageHost: null,

--- a/app/config/staging.js
+++ b/app/config/staging.js
@@ -15,5 +15,13 @@ module.exports = {
     secretKey: 'miniostorageengine',
     bucket: 'rra',
     region: 'us-east-1'
+  },
+  analysisProcess: {
+    service: 'hyper',
+    hyperAccess: null,
+    container: 'wbtransport/rra-analysis',
+    db: null,
+    storageHost: '34.207.194.24',
+    storagePort: 9000
   }
 };

--- a/app/config/staging.js
+++ b/app/config/staging.js
@@ -19,6 +19,7 @@ module.exports = {
   analysisProcess: {
     service: 'hyper',
     hyperAccess: null,
+    hyperSecret: null,
     container: 'wbtransport/rra-analysis',
     db: null,
     storageHost: '34.207.194.24',

--- a/app/routes/scenarios--gen-results.js
+++ b/app/routes/scenarios--gen-results.js
@@ -109,7 +109,7 @@ function spawnAnalysisProcess (projId, scId, opId) {
   // Each Project/Scenario combination can only have one analysis process
   // running.
   let containerName = `analysisp${projId}s${scId}`;
-  let baseOptions = [
+  let args = [
     'run',
     '--name', containerName,
     '-e', `DB_URI=${config.analysisProcess.db}`,
@@ -131,7 +131,7 @@ function spawnAnalysisProcess (projId, scId, opId) {
     case 'docker':
       break;
     case 'hyper':
-      baseOptions.push = (
+      args.push = (
         '-e', `HYPER_ACCESS=${config.analysisProcess.hyperAccess}`,
         '-e', `HYPER_SECRET=${config.analysisProcess.hyperSecret}`
       );
@@ -141,7 +141,7 @@ function spawnAnalysisProcess (projId, scId, opId) {
   }
 
   // Append the name of the image last
-  let args = baseOptions.concat(config.analysisProcess.container);
+  args.push(config.analysisProcess.container);
 
   // Spawn the processing script. It will take care of updating
   // the database with progress.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# install Hyper
+wget https://hyper-install.s3.amazonaws.com/hyper-linux-x86_64.tar.gz
+tar xzf hyper-linux-x86_64.tar.gz
+chmod +x hyper
+mv ./hyper /usr/local/bin


### PR DESCRIPTION
This allows the analysis process to be run on Hyper, instead of a Docker container. Will mostly useful for running the tool in a hosted environment.

To test it, you'd need to:

1. create a Hyper account and add the keys to the config or as env vars
2. have the API, DB and Minio run on a machine that can be accessed from the outside