### PR TITLE
Store time when road network is updated

### DIFF
--- a/app/db/structure.js
+++ b/app/db/structure.js
@@ -61,6 +61,8 @@ export function createScenariosTable () {
       .references('projects.id')
       .onDelete('CASCADE');
     table.json('admin_areas');
+    // Arbitrary additional json data.
+    table.json('data');
     table.timestamps();
 
     table.unique(['project_id', 'name']);

--- a/app/routes/projects--create.js
+++ b/app/routes/projects--create.js
@@ -38,7 +38,11 @@ module.exports = [
           status: 'pending',
           master: true,
           created_at: (new Date()),
-          updated_at: (new Date())
+          updated_at: (new Date()),
+          data: {
+            res_gen_at: 0,
+            rn_updated_at: 0
+          }
         })
         .then(() => reply(projectData))
         .catch(err => reply(Boom.badImplementation(err)));

--- a/app/routes/scenarios--create.js
+++ b/app/routes/scenarios--create.js
@@ -61,7 +61,11 @@ module.exports = [
             master: false,
             project_id: request.params.projId,
             created_at: (new Date()),
-            updated_at: (new Date())
+            updated_at: (new Date()),
+            data: {
+              res_gen_at: 0,
+              rn_updated_at: 0
+            }
           };
 
           return db('scenarios')

--- a/test/test-projects.js
+++ b/test/test-projects.js
@@ -316,6 +316,31 @@ describe('Projects', function () {
         assert.equal(result.description, 'This is the description');
       });
     });
+
+    it('should create a master ghost scenario', function () {
+      return instance.injectThen({
+        method: 'POST',
+        url: '/projects',
+        payload: {
+          name: 'Project and ghost'
+        }
+      }).then(res => {
+        assert.equal(res.statusCode, 200, 'Status code is 200');
+        var result = res.result;
+        assert.equal(result.name, 'Project and ghost');
+
+        return db('scenarios')
+          .select('*')
+          .where('project_id', result.id)
+          .where('master', true)
+          .first()
+          .then(scenario => {
+            assert.equal(scenario.name, 'Main scenario');
+            assert.equal(scenario.data.res_gen_at, 0);
+            assert.equal(scenario.data.rn_updated_at, 0);
+          });
+      });
+    });
   });
 
   describe('PATCH /projects/{projId}', function () {

--- a/test/test-scenarios-create.js
+++ b/test/test-scenarios-create.js
@@ -196,6 +196,8 @@ describe('Scenarios', function () {
         assert.equal(result.master, false);
         assert.equal(result.project_id, 1200);
         assert.equal(typeof result.roadNetworkUpload, 'undefined');
+        assert.equal(result.data.res_gen_at, 0);
+        assert.equal(result.data.rn_updated_at, 0);
 
         return result;
       });

--- a/test/utils/data.js
+++ b/test/utils/data.js
@@ -73,7 +73,11 @@ export function project1000 () {
     'project_id': 1000,
     'master': true,
     'created_at': '2017-02-01T12:00:01.000Z',
-    'updated_at': '2017-02-01T12:00:01.000Z'
+    'updated_at': '2017-02-01T12:00:01.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }));
 }
 
@@ -95,7 +99,11 @@ export function project1002 () {
     'project_id': 1002,
     'master': true,
     'created_at': '2017-02-01T12:00:02.000Z',
-    'updated_at': '2017-02-01T12:00:02.000Z'
+    'updated_at': '2017-02-01T12:00:02.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }));
 }
 
@@ -127,7 +135,11 @@ export function project1001 () {
     'project_id': 1001,
     'master': true,
     'created_at': '2017-02-01T12:00:03.000Z',
-    'updated_at': '2017-02-01T12:00:03.000Z'
+    'updated_at': '2017-02-01T12:00:03.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile({
     'id': 1001,
@@ -170,7 +182,11 @@ export function project1003 () {
     'project_id': 1003,
     'master': true,
     'created_at': '2017-02-01T12:00:04.000Z',
-    'updated_at': '2017-02-01T12:00:04.000Z'
+    'updated_at': '2017-02-01T12:00:04.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile({
     'id': 1003,
@@ -235,7 +251,11 @@ export function project1004 () {
     'project_id': 1004,
     'master': true,
     'created_at': '2017-02-01T12:00:05.000Z',
-    'updated_at': '2017-02-01T12:00:05.000Z'
+    'updated_at': '2017-02-01T12:00:05.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile([
     {
@@ -315,7 +335,11 @@ export function project1100 () {
     'master': true,
     'admin_areas': JSON.stringify(ADMIN_AREAS),
     'created_at': '2017-02-01T12:00:06.000Z',
-    'updated_at': '2017-02-01T12:00:06.000Z'
+    'updated_at': '2017-02-01T12:00:06.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile([
     {
@@ -396,7 +420,11 @@ export function project1200 () {
       'master': true,
       'admin_areas': JSON.stringify(ADMIN_AREAS),
       'created_at': '2017-02-01T12:00:07.000Z',
-      'updated_at': '2017-02-01T12:00:07.000Z'
+      'updated_at': '2017-02-01T12:00:07.000Z',
+      'data': {
+        'res_gen_at': 0,
+        'rn_updated_at': 0
+      }
     },
     {
       'id': 1201,
@@ -407,7 +435,11 @@ export function project1200 () {
       'master': false,
       'admin_areas': JSON.stringify(ADMIN_AREAS),
       'created_at': '2017-02-01T12:00:07.000Z',
-      'updated_at': '2017-02-01T12:00:07.000Z'
+      'updated_at': '2017-02-01T12:00:07.000Z',
+      'data': {
+        'res_gen_at': 0,
+        'rn_updated_at': 0
+      }
     }
   ]))
   .then(() => scenarioFile([
@@ -511,7 +543,11 @@ export function project2000 () {
     'master': true,
     'admin_areas': JSON.stringify(ADMIN_AREAS),
     'created_at': '2017-02-01T12:00:06.000Z',
-    'updated_at': '2017-02-01T12:00:06.000Z'
+    'updated_at': '2017-02-01T12:00:06.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile([
     {
@@ -598,7 +634,11 @@ export function projectBarebones (id) {
     'project_id': id,
     'master': true,
     'created_at': '2017-02-01T12:00:00.000Z',
-    'updated_at': '2017-02-01T12:00:00.000Z'
+    'updated_at': '2017-02-01T12:00:00.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }));
 }
 
@@ -630,7 +670,11 @@ export function projectPendingWithFiles (id) {
     'project_id': id,
     'master': true,
     'created_at': '2017-02-01T12:00:00.000Z',
-    'updated_at': '2017-02-01T12:00:00.000Z'
+    'updated_at': '2017-02-01T12:00:00.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile({
     'id': id,
@@ -696,7 +740,11 @@ export function projectPendingWithAllFiles (id) {
     'project_id': id,
     'master': true,
     'created_at': '2017-02-01T12:00:00.000Z',
-    'updated_at': '2017-02-01T12:00:00.000Z'
+    'updated_at': '2017-02-01T12:00:00.000Z',
+    'data': {
+      'res_gen_at': 0,
+      'rn_updated_at': 0
+    }
   }))
   .then(() => scenarioFile([
     {


### PR DESCRIPTION
Related to https://github.com/WorldBank-Transport/Rural-Road-Accessibility/issues/97.

To display a message to the user when the results are outdated, we need to know the last time they were generated.
This value will then be compared with the last time the road network was updated, and we'll know whether the results are outdated or not.