### PR TITLE
Make Hyper container configurable. Fix #101

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following options must be set:
   - `analysisProcess.service` - The service to run the analysis on. Either `docker` (for local development and off-line) or `hyper`. [ANL_SERVICE]
   - `analysisProcess.hyperAccess` - Access key for Hyper. [HYPER_ACCESS]
   - `analysisProcess.hyperSecret` - Secret key for Hyper. [HYPER_SECRET]
-  - `analysisProcess.hyperSize` - The size of the Hyper container. If not specified, it will use Hyper's default container. [HYPER_SIZE]
+  - `analysisProcess.hyperSize` - The size of the Hyper container. If not specified, it will use [Hyper's](https://hyper.sh) default container. [HYPER_SIZE]
   - `analysisProcess.container` - The name of the rra-analysis container (Default wbtransport/rra-analysis:latest-stable) [ANL_CONTAINER]
   - `analysisProcess.db` - The database connection string. When using Docker for the analysis process, the host will be the name of the database container (`rra-postgis`). When using Hyper, this will be the IP of your hosted database [ANL_DB]
   - `analysisProcess.storageHost` - The host of the storage service. When using Docker, this will be the name of the storage container (`rra-minio`). When using Hyper, this will be the IP of the storage host. [ANL_STORAGE_HOST]

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following options must be set:
   - `analysisProcess.service` - The service to run the analysis on. Either `docker` (for local development and off-line) or `hyper`. [ANL_SERVICE]
   - `analysisProcess.hyperAccess` - Access key for Hyper. [HYPER_ACCESS]
   - `analysisProcess.hyperSecret` - Secret key for Hyper. [HYPER_SECRET]
+  - `analysisProcess.hyperSize` - The size of the Hyper container. If not specified, it will use Hyper's default container. [HYPER_SIZE]
   - `analysisProcess.container` - The name of the rra-analysis container (Default wbtransport/rra-analysis:latest-stable) [ANL_CONTAINER]
   - `analysisProcess.db` - The database connection string. When using Docker for the analysis process, the host will be the name of the database container (`rra-postgis`). When using Hyper, this will be the IP of your hosted database [ANL_DB]
   - `analysisProcess.storageHost` - The host of the storage service. When using Docker, this will be the name of the storage container (`rra-minio`). When using Hyper, this will be the IP of the storage host. [ANL_STORAGE_HOST]

--- a/app/config.js
+++ b/app/config.js
@@ -51,6 +51,7 @@ config.analysisProcess.storageHost = process.env.ANL_STORAGE_HOST || config.anal
 config.analysisProcess.storagePort = process.env.ANL_STORAGE_PORT || config.analysisProcess.storagePort;
 config.analysisProcess.hyperAccess = process.env.HYPER_ACCESS || config.analysisProcess.hyperAccess;
 config.analysisProcess.hyperSecret = process.env.HYPER_SECRET || config.analysisProcess.hyperSecret;
+config.analysisProcess.hyperSize = process.env.HYPER_SIZE || config.analysisProcess.hyperSize;
 
 config.baseDir = __dirname;
 

--- a/app/config/production.js
+++ b/app/config/production.js
@@ -20,6 +20,7 @@ module.exports = {
     service: null,
     hyperAccess: null,
     hyperSecret: null,
+    hyperSize: null,
     container: 'wbtransport/rra-analysis:latest-stable',
     db: null,
     storageHost: null,

--- a/app/config/staging.js
+++ b/app/config/staging.js
@@ -20,6 +20,7 @@ module.exports = {
     service: 'hyper',
     hyperAccess: null,
     hyperSecret: null,
+    hyperSize: null,
     container: 'wbtransport/rra-analysis:latest-dev',
     db: null,
     storageHost: '34.207.194.24',

--- a/app/config/test.js
+++ b/app/config/test.js
@@ -19,6 +19,7 @@ module.exports = {
     service: null,
     hyperAccess: null,
     hyperSecret: null,
+    hyperSize: null,
     container: null,
     db: null,
     storageHost: null,

--- a/app/routes/scenarios--gen-results.js
+++ b/app/routes/scenarios--gen-results.js
@@ -181,6 +181,11 @@ function spawnAnalysisProcess (projId, scId, opId) {
         '-e', `HYPER_ACCESS=${config.analysisProcess.hyperAccess}`,
         '-e', `HYPER_SECRET=${config.analysisProcess.hyperSecret}`
       );
+      if (config.analysisProcess.hyperSize) {
+        args.push(
+          `--size=${config.analysisProcess.hyperSize}`
+        );
+      }
       break;
     default:
       throw new Error(`${service} is not a valid option. The analysis should be run on 'docker' or 'hyper'. Check your config file or env variables.`);


### PR DESCRIPTION
Use a config variable to define the container size used on Hyper.

If left `null`, it will use Hyper's default container size.
If the user specifies an invalid size, the frontend will throw:

```
hyper: Error response from daemon: Illegal container size: l321.
```